### PR TITLE
Change line ocr

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tassadar is an OCR service based on [tesseract](https://github.com/tesseract-ocr
 Tassadar provides the following ocr APIs:
 
 - `get_ocr(1:binary image)`: accept image binary data, return ocr text result.
-- `line_ocr(1:bianry image)`: if you do image segmentation by yourself, you can just do ocr line by line, which gives you a more accurate result.
+- `line_ocr(1:bianry image)`: do ocr line by line.
 - `version()`: return the current version.
 
 ### Docker

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from setuptools import setup, find_packages
 
-VERSION = '0.1.0'
+VERSION = '0.2.0'
 
 REQS = [
     'thrift==0.11.0',

--- a/python/tassadar_client/gen_py/tassadar/ttypes.py
+++ b/python/tassadar_client/gen_py/tassadar/ttypes.py
@@ -14,56 +14,5 @@ import sys
 
 from thrift.transport import TTransport
 all_structs = []
-
-
-class PageSegMode(object):
-    PSM_OSD_ONLY = 0
-    PSM_AUTO_OSD = 1
-    PSM_AUTO_ONLY = 2
-    PSM_AUTO = 3
-    PSM_SINGLE_COLUMN = 4
-    PSM_SINGLE_BLOCK_VERT_TEXT = 5
-    PSM_SINGLE_BLOCK = 6
-    PSM_SINGLE_LINE = 7
-    PSM_SINGLE_WORD = 8
-    PSM_CIRCLE_WORD = 9
-    PSM_SINGLE_CHAR = 10
-    PSM_SPARSE_TEXT = 11
-    PSM_SPARSE_TEXT_OSD = 12
-    PSM_COUNT = 13
-
-    _VALUES_TO_NAMES = {
-        0: "PSM_OSD_ONLY",
-        1: "PSM_AUTO_OSD",
-        2: "PSM_AUTO_ONLY",
-        3: "PSM_AUTO",
-        4: "PSM_SINGLE_COLUMN",
-        5: "PSM_SINGLE_BLOCK_VERT_TEXT",
-        6: "PSM_SINGLE_BLOCK",
-        7: "PSM_SINGLE_LINE",
-        8: "PSM_SINGLE_WORD",
-        9: "PSM_CIRCLE_WORD",
-        10: "PSM_SINGLE_CHAR",
-        11: "PSM_SPARSE_TEXT",
-        12: "PSM_SPARSE_TEXT_OSD",
-        13: "PSM_COUNT",
-    }
-
-    _NAMES_TO_VALUES = {
-        "PSM_OSD_ONLY": 0,
-        "PSM_AUTO_OSD": 1,
-        "PSM_AUTO_ONLY": 2,
-        "PSM_AUTO": 3,
-        "PSM_SINGLE_COLUMN": 4,
-        "PSM_SINGLE_BLOCK_VERT_TEXT": 5,
-        "PSM_SINGLE_BLOCK": 6,
-        "PSM_SINGLE_LINE": 7,
-        "PSM_SINGLE_WORD": 8,
-        "PSM_CIRCLE_WORD": 9,
-        "PSM_SINGLE_CHAR": 10,
-        "PSM_SPARSE_TEXT": 11,
-        "PSM_SPARSE_TEXT_OSD": 12,
-        "PSM_COUNT": 13,
-    }
 fix_spec(all_structs)
 del all_structs

--- a/src/gen-cpp/tassadar_types.cpp
+++ b/src/gen-cpp/tassadar_types.cpp
@@ -13,48 +13,4 @@
 
 
 
-int _kPageSegModeValues[] = {
-  PageSegMode::PSM_OSD_ONLY,
-  PageSegMode::PSM_AUTO_OSD,
-  PageSegMode::PSM_AUTO_ONLY,
-  PageSegMode::PSM_AUTO,
-  PageSegMode::PSM_SINGLE_COLUMN,
-  PageSegMode::PSM_SINGLE_BLOCK_VERT_TEXT,
-  PageSegMode::PSM_SINGLE_BLOCK,
-  PageSegMode::PSM_SINGLE_LINE,
-  PageSegMode::PSM_SINGLE_WORD,
-  PageSegMode::PSM_CIRCLE_WORD,
-  PageSegMode::PSM_SINGLE_CHAR,
-  PageSegMode::PSM_SPARSE_TEXT,
-  PageSegMode::PSM_SPARSE_TEXT_OSD,
-  PageSegMode::PSM_COUNT
-};
-const char* _kPageSegModeNames[] = {
-  "PSM_OSD_ONLY",
-  "PSM_AUTO_OSD",
-  "PSM_AUTO_ONLY",
-  "PSM_AUTO",
-  "PSM_SINGLE_COLUMN",
-  "PSM_SINGLE_BLOCK_VERT_TEXT",
-  "PSM_SINGLE_BLOCK",
-  "PSM_SINGLE_LINE",
-  "PSM_SINGLE_WORD",
-  "PSM_CIRCLE_WORD",
-  "PSM_SINGLE_CHAR",
-  "PSM_SPARSE_TEXT",
-  "PSM_SPARSE_TEXT_OSD",
-  "PSM_COUNT"
-};
-const std::map<int, const char*> _PageSegMode_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(14, _kPageSegModeValues, _kPageSegModeNames), ::apache::thrift::TEnumIterator(-1, NULL, NULL));
-
-std::ostream& operator<<(std::ostream& out, const PageSegMode::type& val) {
-  std::map<int, const char*>::const_iterator it = _PageSegMode_VALUES_TO_NAMES.find(val);
-  if (it != _PageSegMode_VALUES_TO_NAMES.end()) {
-    out << it->second;
-  } else {
-    out << static_cast<int>(val);
-  }
-  return out;
-}
-
 

--- a/src/gen-cpp/tassadar_types.h
+++ b/src/gen-cpp/tassadar_types.h
@@ -20,29 +20,6 @@
 
 
 
-struct PageSegMode {
-  enum type {
-    PSM_OSD_ONLY = 0,
-    PSM_AUTO_OSD = 1,
-    PSM_AUTO_ONLY = 2,
-    PSM_AUTO = 3,
-    PSM_SINGLE_COLUMN = 4,
-    PSM_SINGLE_BLOCK_VERT_TEXT = 5,
-    PSM_SINGLE_BLOCK = 6,
-    PSM_SINGLE_LINE = 7,
-    PSM_SINGLE_WORD = 8,
-    PSM_CIRCLE_WORD = 9,
-    PSM_SINGLE_CHAR = 10,
-    PSM_SPARSE_TEXT = 11,
-    PSM_SPARSE_TEXT_OSD = 12,
-    PSM_COUNT = 13
-  };
-};
-
-extern const std::map<int, const char*> _PageSegMode_VALUES_TO_NAMES;
-
-std::ostream& operator<<(std::ostream& out, const PageSegMode::type& val);
-
 
 
 #endif

--- a/src/tassadar.cpp
+++ b/src/tassadar.cpp
@@ -1,21 +1,14 @@
 #include "tassadar.hpp"
 
 #include <cstdlib>
-#include <map>
 
 #include <tesseract/baseapi.h>
 #include <leptonica/allheaders.h>
 
-#include "gen-cpp/tassadar_types.h"
 
 inline Pix *StringToPix(const std::string &image_str) {
   return pixReadMem(reinterpret_cast<const l_uint8*>(image_str.c_str()), image_str.size());
 }
-
-std::map<PageSegMode::type, tesseract::PageSegMode> psm_map = {
-  {PageSegMode::PSM_SINGLE_LINE, tesseract::PSM_SINGLE_LINE},
-  {PageSegMode::PSM_SINGLE_BLOCK, tesseract::PSM_SINGLE_BLOCK}
-};
 
 tesseract::TessBaseAPI* TassadarServerHandler::get_tess_api(
     const std::string &lang) {

--- a/src/tassadar.cpp
+++ b/src/tassadar.cpp
@@ -27,16 +27,13 @@ tesseract::TessBaseAPI* TassadarServerHandler::get_tess_api(
   return api;
 }
 
-void TassadarServerHandler::ocr_process(std::string &_return,
-                                        const std::string &image,
-                                        const PageSegMode::type &psm) {
+void TassadarServerHandler::get_ocr(std::string &_return, const std::string &image) {
   Pix *image_pix = StringToPix(image);
   if (image_pix == NULL) {
     syslog(LOG_ERR, "PixReadMem Error.");
     return;
   }
 
-  api_->SetPageSegMode(psm_map[psm]);
   api_->SetImage(image_pix);
 
   char *out_text;
@@ -47,10 +44,31 @@ void TassadarServerHandler::ocr_process(std::string &_return,
   pixDestroy(&image_pix);
 }
 
-void TassadarServerHandler::get_ocr(std::string& _return, const std::string& image) {
-  ocr_process(_return, image, PageSegMode::PSM_SINGLE_BLOCK);
-}
-
 void TassadarServerHandler::line_ocr(std::string& _return, const std::string& image) {
-  ocr_process(_return, image, PageSegMode::PSM_SINGLE_LINE);
+  Pix *image_pix = StringToPix(image);
+  if (image_pix == NULL) {
+    syslog(LOG_ERR, "PixReadMem Error.");
+    return;
+  }
+
+  std::vector<std::string> result_lines;
+  api_->SetImage(image_pix);
+  api_->Recognize(0);
+  tesseract::ResultIterator* ri = api_->GetIterator();
+  tesseract::PageIteratorLevel level = tesseract::RIL_TEXTLINE;
+  if (ri != 0) {
+    do {
+      const char* line_text = ri->GetUTF8Text(level);
+      result_lines.push_back(line_text);
+      delete[] line_text;
+    } while (ri->Next(level));
+  }
+
+  std::string result;
+  for (std::string& line: result_lines) {
+    result += line;
+  }
+  _return = result;
+
+  pixDestroy(&image_pix);
 }

--- a/src/tassadar.hpp
+++ b/src/tassadar.hpp
@@ -9,7 +9,6 @@
 #include <tesseract/baseapi.h>
 
 #include "gen-cpp/TassadarServer.h"
-#include "gen-cpp/tassadar_types.h"
 
 struct Pix;
 namespace tesseract {
@@ -46,9 +45,6 @@ class TassadarServerHandler : virtual public TassadarServerIf {
 
  protected:
   tesseract::TessBaseAPI *get_tess_api(const std::string &lang);
-  void ocr_process(std::string &_return,
-                   const std::string &image,
-                   const PageSegMode::type &psm);
 
  private:
   char *tessdata_;

--- a/src/tassadar.hpp
+++ b/src/tassadar.hpp
@@ -49,7 +49,7 @@ class TassadarServerHandler : virtual public TassadarServerIf {
  private:
   char *tessdata_;
   tesseract::TessBaseAPI *api_;
-  const std::string version_ = "0.1.0";
+  const std::string version_ = "0.2.0";
 };
 
 #endif

--- a/tassadar.thrift
+++ b/tassadar.thrift
@@ -1,9 +1,3 @@
-enum PageSegMode {
-    PSM_OSD_ONLY, PSM_AUTO_OSD, PSM_AUTO_ONLY, PSM_AUTO, PSM_SINGLE_COLUMN, PSM_SINGLE_BLOCK_VERT_TEXT,
-    PSM_SINGLE_BLOCK, PSM_SINGLE_LINE, PSM_SINGLE_WORD, PSM_CIRCLE_WORD, PSM_SINGLE_CHAR, PSM_SPARSE_TEXT,
-    PSM_SPARSE_TEXT_OSD, PSM_COUNT
-}
-
 service TassadarServer {
     string version(),
     string get_ocr(1:binary image),


### PR DESCRIPTION
- Do line segmentation inside `line_ocr()` with `tesseract::ResultIterator`.
- Remove PSM types from thrift.